### PR TITLE
Split CI workflows into separate PR and release workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,8 @@
 name: Deploy Ghost Interface
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -16,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18' 
+          node-version: '18'
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Build Ghost Interface CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build the React app
+        run: yarn build


### PR DESCRIPTION
### Description

This PR splits the existing CI workflow into two separate workflows:

1. **Build on Pull Request to Main**:
    - This workflow runs when a pull request is created targeting the `main` branch.
    - It performs the build step to ensure that the code compiles correctly.
    - If the build succeeds, the workflow passes; otherwise, it fails.

2. **Deploy Ghost Interface on Release**:
    - This workflow runs when a new release is created.
    - It performs the full build and deploy process, deploying the built React app to the `build` branch.

### Changes Made

- **Created `Build Ghost Interface CI` Workflow**:
  - Triggers on pull request creation to the `main` branch.
  - Checks out the code, sets up Node.js, installs dependencies, and builds the React app.

- **Modified `Deploy Ghost Interface` Workflow**:
  - Now triggers on release creation instead of all pushes to `main`.
  - Includes steps to check out the code, set up Node.js, install dependencies, build the React app, and deploy to the `build` branch.

### Rationale

Splitting the workflows helps to:
- Ensure that code changes are validated through a build step before merging into `main`.
- Automate the deployment process only on release creation, reducing unnecessary deployments.

### Testing

- Verified that the `Build Ghost Interface on PR` workflow runs correctly on pull request creation.
- Verified that the `Deploy Ghost Interface on Release` workflow runs correctly on release creation and completes the build and deploy steps.

### Related Issues

- Addresses the need to separate build validation and deployment workflows for better CI/CD management.
